### PR TITLE
Feature set rename state to command

### DIFF
--- a/cmd/entities/hosts/features.go
+++ b/cmd/entities/hosts/features.go
@@ -26,7 +26,7 @@ func newListEBMFeaturesCmd(cmdContext *base.CmdContext) *cobra.Command {
 
 type featureSetFlags struct {
 	Feature           string
-	State             string
+	Command           string
 	IPXEConfig        string
 	AuthMethod        []string
 	SSHKeyFingerprint []string
@@ -53,13 +53,13 @@ func newEBMFeatureSetCmd(cmdContext *base.CmdContext) *cobra.Command {
 				err    error
 			)
 
-			switch flags.State {
+			switch flags.Command {
 			case "activate":
 				result, err = activateEBMFeature(ctx, scClient, id, flags)
 			case "deactivate":
 				result, err = deactivateEBMFeature(ctx, scClient, id, flags.Feature)
 			default:
-				return fmt.Errorf("invalid state %q: must be activate or deactivate", flags.State)
+				return fmt.Errorf("invalid command %q: must be activate or deactivate", flags.Command)
 			}
 
 			if err != nil {
@@ -76,13 +76,13 @@ func newEBMFeatureSetCmd(cmdContext *base.CmdContext) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.Feature, "feature", "", "feature name (required)")
-	cmd.Flags().StringVar(&flags.State, "state", "", "desired state: activate or deactivate (required)")
+	cmd.Flags().StringVar(&flags.Command, "command", "", "command to run: activate or deactivate (required)")
 	cmd.Flags().StringVar(&flags.IPXEConfig, "ipxe-config", "", "iPXE config script (for private_ipxe_boot)")
 	cmd.Flags().StringArrayVar(&flags.AuthMethod, "auth-method", nil, "auth method: password, ssh_key (for host_rescue_mode)")
 	cmd.Flags().StringArrayVar(&flags.SSHKeyFingerprint, "ssh-key-fingerprint", nil, "SSH key fingerprint (for host_rescue_mode with ssh_key auth)")
 
 	_ = cmd.MarkFlagRequired("feature")
-	_ = cmd.MarkFlagRequired("state")
+	_ = cmd.MarkFlagRequired("command")
 
 	return cmd
 }

--- a/cmd/entities/hosts/features_test.go
+++ b/cmd/entities/hosts/features_test.go
@@ -162,7 +162,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 	}{
 		{
 			name:           "activate feature",
-			args:           []string{testServerID, "--feature", "disaggregated_public_ports", "--state", "activate", "--output", "json"},
+			args:           []string{testServerID, "--feature", "disaggregated_public_ports", "--command", "activate", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -172,7 +172,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name: "deactivate feature",
-			args: []string{testServerID, "--feature", "disaggregated_public_ports", "--state", "deactivate", "--output", "json"},
+			args: []string{testServerID, "--feature", "disaggregated_public_ports", "--command", "deactivate", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -182,7 +182,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:           "activate private_ipxe_boot with ipxe-config",
-			args:           []string{testServerID, "--feature", "private_ipxe_boot", "--state", "activate", "--ipxe-config", "#!ipxe\nchain http://boot.example.com", "--output", "json"},
+			args:           []string{testServerID, "--feature", "private_ipxe_boot", "--command", "activate", "--ipxe-config", "#!ipxe\nchain http://boot.example.com", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set_private_ipxe_boot.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -194,7 +194,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:           "deactivate private_ipxe_boot",
-			args:           []string{testServerID, "--feature", "private_ipxe_boot", "--state", "deactivate", "--output", "json"},
+			args:           []string{testServerID, "--feature", "private_ipxe_boot", "--command", "deactivate", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set_private_ipxe_boot.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -204,7 +204,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:           "activate host_rescue_mode with password auth",
-			args:           []string{testServerID, "--feature", "host_rescue_mode", "--state", "activate", "--auth-method", "password", "--output", "json"},
+			args:           []string{testServerID, "--feature", "host_rescue_mode", "--command", "activate", "--auth-method", "password", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set_host_rescue_mode.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -216,7 +216,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:           "activate host_rescue_mode with ssh_key auth",
-			args:           []string{testServerID, "--feature", "host_rescue_mode", "--state", "activate", "--auth-method", "ssh_key", "--ssh-key-fingerprint", "aa:bb:cc", "--output", "json"},
+			args:           []string{testServerID, "--feature", "host_rescue_mode", "--command", "activate", "--auth-method", "ssh_key", "--ssh-key-fingerprint", "aa:bb:cc", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set_host_rescue_mode.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -229,7 +229,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:           "deactivate host_rescue_mode",
-			args:           []string{testServerID, "--feature", "host_rescue_mode", "--state", "deactivate", "--output", "json"},
+			args:           []string{testServerID, "--feature", "host_rescue_mode", "--command", "deactivate", "--output", "json"},
 			expectedOutput: testutils.ReadFixture(filepath.Join(featuresFixtureBasePath, "feature_set_host_rescue_mode.json")),
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -239,7 +239,7 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 		},
 		{
 			name:        "api error",
-			args:        []string{testServerID, "--feature", "disaggregated_public_ports", "--state", "activate"},
+			args:        []string{testServerID, "--feature", "disaggregated_public_ports", "--command", "activate"},
 			expectError: true,
 			configureMock: func(mock *mocks.MockHostsService) {
 				mock.EXPECT().
@@ -248,13 +248,13 @@ func TestEBMFeatureSetCmd(t *testing.T) {
 			},
 		},
 		{
-			name:        "invalid state",
-			args:        []string{testServerID, "--feature", "disaggregated_public_ports", "--state", "invalid"},
+			name:        "invalid command",
+			args:        []string{testServerID, "--feature", "disaggregated_public_ports", "--command", "invalid"},
 			expectError: true,
 		},
 		{
 			name:        "unsupported feature",
-			args:        []string{testServerID, "--feature", "unknown_feature", "--state", "activate"},
+			args:        []string{testServerID, "--feature", "unknown_feature", "--command", "activate"},
 			expectError: true,
 		},
 	}

--- a/docs/srvctl-hosts-ebm-feature-set/description.md
+++ b/docs/srvctl-hosts-ebm-feature-set/description.md
@@ -1,6 +1,6 @@
 This command activates or deactivates a feature on the selected enterprise bare metal server.
 
-The `--feature` and `--state` flags are required. The `--state` flag accepts `activate` or `deactivate`.
+The `--feature` and `--command` flags are required. The `--command` flag accepts `activate` or `deactivate`.
 
 Supported feature names:
 

--- a/docs/srvctl-hosts-ebm-feature-set/examples.md
+++ b/docs/srvctl-hosts-ebm-feature-set/examples.md
@@ -1,13 +1,13 @@
 A command to activate disaggregated public ports on the server with the "ex4mp1eID" ID:
 
 ```
-srvctl hosts ebm feature-set ex4mp1eID --feature disaggregated_public_ports --state activate
+srvctl hosts ebm feature-set ex4mp1eID --feature disaggregated_public_ports --command activate
 ```
 
 A command to deactivate disaggregated public ports on the server with the "ex4mp1eID" ID:
 
 ```
-srvctl hosts ebm feature-set ex4mp1eID --feature disaggregated_public_ports --state deactivate
+srvctl hosts ebm feature-set ex4mp1eID --feature disaggregated_public_ports --command deactivate
 ```
 
 A command to activate rescue mode with password and SSH key authentication:
@@ -15,7 +15,7 @@ A command to activate rescue mode with password and SSH key authentication:
 ```
 srvctl hosts ebm feature-set ex4mp1eID \
 	--feature host_rescue_mode \
-	--state activate \
+	--command activate \
 	--auth-method password \
 	--auth-method ssh_key \
 	--ssh-key-fingerprint aa:bb:cc:dd:ee:ff
@@ -26,12 +26,12 @@ A command to activate private iPXE boot with a custom script:
 ```
 srvctl hosts ebm feature-set ex4mp1eID \
 	--feature private_ipxe_boot \
-	--state activate \
+	--command activate \
 	--ipxe-config "#!ipxe\nchain http://boot.example.com/script.ipxe"
 ```
 
 A command to deactivate rescue mode:
 
 ```
-srvctl hosts ebm feature-set ex4mp1eID --feature host_rescue_mode --state deactivate
+srvctl hosts ebm feature-set ex4mp1eID --feature host_rescue_mode --command deactivate
 ```


### PR DESCRIPTION
For hosts ebm feature-set rename flag 'state' to 'command'.
Update docs.